### PR TITLE
Addressing requested changes

### DIFF
--- a/src/lib/sql/fdsnws/getEventSummary.sql
+++ b/src/lib/sql/fdsnws/getEventSummary.sql
@@ -8,7 +8,7 @@ CREATE PROCEDURE getEventSummary(
   OUT out_event_type TEXT,
   OUT out_azimuthal_gap DOUBLE,
   OUT out_magnitude_type TEXT,
-  OUT out_region TEXT CHARACTER SET utf8,
+  OUT out_region TEXT,
   OUT out_producttypes TEXT,
   OUT out_eventids TEXT,
   OUT out_eventsources TEXT,

--- a/src/lib/sql/fdsnws/getProductProperty.sql
+++ b/src/lib/sql/fdsnws/getProductProperty.sql
@@ -1,7 +1,7 @@
 delimiter //
 DROP PROCEDURE IF EXISTS getProductProperty//
 CREATE PROCEDURE getProductProperty(IN in_productid INT,
-  IN in_name VARCHAR(255), OUT out_value TEXT CHARACTER SET utf8)
+  IN in_name VARCHAR(255), OUT out_value TEXT)
   READS SQL DATA
 BEGIN
   DECLARE done INT DEFAULT 0;

--- a/src/lib/sql/fdsnws/updateEventSummary.sql
+++ b/src/lib/sql/fdsnws/updateEventSummary.sql
@@ -9,7 +9,7 @@ BEGIN
   DECLARE event_type TEXT;
   DECLARE azimuthal_gap DOUBLE;
   DECLARE magnitude_type TEXT;
-  DECLARE region TEXT CHARACTER SET utf8;
+  DECLARE region TEXT;
   DECLARE types TEXT;
   DECLARE eventids TEXT;
   DECLARE eventsources TEXT;

--- a/src/lib/sql/utf8-update.sql
+++ b/src/lib/sql/utf8-update.sql
@@ -1,15 +1,17 @@
-## Update existing tables used by earthquake-event-ws.
+-- Update existing tables used by earthquake-event-ws.
 
-## Change character encoding to UTF-8. If run in a mysql replication
-## environment, run the script on the "master" host and changes will be
-## replicated to the "slave" instance via the statement based
-## replication strategy.
+-- Change character encoding to UTF-8. If run in a mysql replication
+-- environment, run the script on the "master" host and changes will be
+-- replicated to the "slave" instance via the statement based
+-- replication strategy.
 
-## Database character set
+SET NAMES utf8
+
+-- Database character set
 ALTER DATABASE product_index
 DEFAULT CHARACTER SET = utf8;
 
-## Column character set
+-- Column character set
 ALTER TABLE event CONVERT TO CHARACTER SET utf8;
 ALTER TABLE eventSummary CONVERT TO CHARACTER SET utf8;
 ALTER TABLE extentSummary CONVERT TO CHARACTER SET utf8;
@@ -22,7 +24,7 @@ ALTER TABLE productSummaryEventStatus CONVERT TO CHARACTER SET utf8;
 ALTER TABLE productSummaryLink CONVERT TO CHARACTER SET utf8;
 ALTER TABLE productSummaryProperty CONVERT TO CHARACTER SET utf8;
 
-## Stored procedure region/title/place character set
+-- Stored procedure region/title/place character set
 SOURCE fdsnws/getEventSummary.sql;
 SOURCE fdsnws/updateEventSummary.sql;
 SOURCE fdsnws/getProductProperty.sql;


### PR DESCRIPTION
So far:
- Used `SET NAMES utf8` before procedure creation to make _all_ names UTF-8
- Updated comments (SQL uses `-`, not `#`)